### PR TITLE
Fix Render deployment path issues using standard WSGI approach

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn --bind 0.0.0.0:$PORT --chdir src/web app:app
+web: gunicorn --bind 0.0.0.0:$PORT wsgi:app

--- a/render.yaml
+++ b/render.yaml
@@ -6,7 +6,7 @@ services:
       pip install --upgrade pip setuptools wheel
       pip install --no-cache-dir --prefer-binary --only-binary=:all: -r requirements.txt || pip install --no-cache-dir -r requirements.txt
       cd src/web && python -c "from app import app, db; app.app_context().push(); db.create_all()"
-    startCommand: cd src/web && gunicorn --bind 0.0.0.0:$PORT app:app
+    startCommand: gunicorn --bind 0.0.0.0:$PORT wsgi:app
     envVars:
       - key: DATABASE_URL
         value: sqlite:///instance/invivodb.db

--- a/wsgi.py
+++ b/wsgi.py
@@ -2,8 +2,7 @@
 """
 WSGI Entry Point for InvivoDB
 
-This file serves as the entry point for WSGI servers.
-Note: With current Procfile setup, this file is not actively used.
+This is the main WSGI entry point that Render/Gunicorn will use.
 """
 
 import sys
@@ -13,13 +12,8 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
 
 # Import the Flask app
-try:
-    from web.app import app
-except ImportError as e:
-    print(f"Import error: {e}")
-    # Fallback for different path structures
-    sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src', 'web'))
-    from app import app
+from web.app import app
 
+# This is what Gunicorn looks for
 if __name__ == "__main__":
-    app.run()
+    app.run(debug=False)


### PR DESCRIPTION
- Update wsgi.py to be the proper WSGI entry point with correct imports
- Use standard wsgi:app pattern instead of app:app
- Fix Python path resolution in wsgi.py for src/web/app.py
- Remove cd commands and use proper WSGI configuration
- This follows Flask deployment best practices